### PR TITLE
Add a configurable sanitation of link labels to allow stripping out characters like # and @ for nostr use case

### DIFF
--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
@@ -1,10 +1,8 @@
 package com.zachklipp.richtext.sample
 
 import android.widget.Toast
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -30,7 +28,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
@@ -160,7 +157,7 @@ import com.halilibo.richtext.ui.string.RichTextString
 class MyMediaRenderer: BasicMediaRenderer() {
   override fun renderNostrUri(uri: String, richTextStringBuilder: RichTextString.Builder) {
     renderInline(richTextStringBuilder) {
-      Text("${uri}")
+      Text(uri)
     }
   }
 
@@ -176,6 +173,8 @@ class MyMediaRenderer: BasicMediaRenderer() {
   }
 
   override fun shouldRenderLinkPreview(title: String?, uri: String): Boolean { return uri.contains("image%2Fjpeg") }
+
+  override fun shouldSanitizeUriLabel(): Boolean { return true }
 }
 
 @Composable

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
@@ -175,6 +175,8 @@ class MyMediaRenderer: BasicMediaRenderer() {
   override fun shouldRenderLinkPreview(title: String?, uri: String): Boolean { return uri.contains("image%2Fjpeg") }
 
   override fun shouldSanitizeUriLabel(): Boolean { return true }
+
+  override fun sanitizeUriLabel(label: String): String = label.filterNot { it == '#' || it == '@' }
 }
 
 @Composable

--- a/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
+++ b/android-sample/src/main/java/com/zachklipp/richtext/sample/MarkdownSample.kt
@@ -284,6 +284,10 @@ private val sampleMarkdown = """
 
   Or leave it empty and use the [link text itself].
   
+  Fake hashtag link: [#Amethyst](https://www.google.com)
+  
+  Fake profile link: [@Amethyst](https://www.google.com)
+  
   Autolink option will detect text links like https://www.google.com and turn them into Markdown links automatically.
 
   ---

--- a/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/BasicMediaRenderer.kt
+++ b/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/BasicMediaRenderer.kt
@@ -6,7 +6,6 @@ import com.halilibo.richtext.ui.MediaRenderer
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.PlaceholderVerticalAlign
-import androidx.compose.ui.text.PlaceholderVerticalAlign.Companion
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.halilibo.richtext.ui.string.InlineContent
@@ -41,6 +40,8 @@ public open class BasicMediaRenderer: MediaRenderer {
   }
 
   override fun shouldRenderLinkPreview(title: String?, uri: String): Boolean { return false }
+
+  override fun shouldSanitizeUriLabel(): Boolean { return false }
 
   public fun renderInline(richTextStringBuilder: RichTextString.Builder, innerComposable: @Composable () -> Unit) {
     richTextStringBuilder.appendInlineContent(

--- a/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/BasicMediaRenderer.kt
+++ b/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/BasicMediaRenderer.kt
@@ -43,6 +43,8 @@ public open class BasicMediaRenderer: MediaRenderer {
 
   override fun shouldSanitizeUriLabel(): Boolean { return false }
 
+  override fun sanitizeUriLabel(label: String): String { return label }
+
   public fun renderInline(richTextStringBuilder: RichTextString.Builder, innerComposable: @Composable () -> Unit) {
     richTextStringBuilder.appendInlineContent(
       content = InlineContent(

--- a/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
+++ b/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
@@ -139,7 +139,7 @@ private fun computeRichTextString(astNode: AstNode, renderer: MediaRenderer): Ri
         }
         is AstStrongEmphasis -> richTextStringBuilder.pushFormat(RichTextString.Format.Bold)
         is AstText -> {
-          if (currentNode.links.parent?.type is AstLink) {
+          if ((currentNode.links.parent?.type is AstLink) && renderer.shouldSanitizeUriLabel()) {
             richTextStringBuilder.append(stripHashAndAt(currentNodeType.literal))
           } else {
             richTextStringBuilder.append(currentNodeType.literal)

--- a/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
+++ b/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
@@ -140,7 +140,7 @@ private fun computeRichTextString(astNode: AstNode, renderer: MediaRenderer): Ri
         is AstStrongEmphasis -> richTextStringBuilder.pushFormat(RichTextString.Format.Bold)
         is AstText -> {
           if (renderer.shouldSanitizeUriLabel() && currentNode.links.parent?.type is AstLink) {
-            renderer.sanitizeUriLabel(currentNodeType.literal)
+            richTextStringBuilder.append(renderer.sanitizeUriLabel(currentNodeType.literal))
           } else {
             richTextStringBuilder.append(currentNodeType.literal)
           }

--- a/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
+++ b/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
@@ -139,14 +139,11 @@ private fun computeRichTextString(astNode: AstNode, renderer: MediaRenderer): Ri
         }
         is AstStrongEmphasis -> richTextStringBuilder.pushFormat(RichTextString.Format.Bold)
         is AstText -> {
-          val text = currentNodeType.literal
-          val sanitizedText = if (renderer.shouldSanitizeUriLabel() && currentNode.links.parent?.type is AstLink) {
-            renderer.sanitizeUriLabel(text)
+          if (renderer.shouldSanitizeUriLabel() && currentNode.links.parent?.type is AstLink) {
+            renderer.sanitizeUriLabel(currentNodeType.literal)
           } else {
-            text
+            richTextStringBuilder.append(currentNodeType.literal)
           }
-          richTextStringBuilder.append(sanitizedText)
-
           null
         }
         is AstLinkReferenceDefinition -> richTextStringBuilder.pushFormat(

--- a/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
+++ b/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
@@ -139,11 +139,13 @@ private fun computeRichTextString(astNode: AstNode, renderer: MediaRenderer): Ri
         }
         is AstStrongEmphasis -> richTextStringBuilder.pushFormat(RichTextString.Format.Bold)
         is AstText -> {
-          if ((currentNode.links.parent?.type is AstLink) && renderer.shouldSanitizeUriLabel()) {
-            richTextStringBuilder.append(stripHashAndAt(currentNodeType.literal))
+          val text = currentNodeType.literal
+          val sanitizedText = if (renderer.shouldSanitizeUriLabel() && currentNode.links.parent?.type is AstLink) {
+            stripHashAndAt(text)
           } else {
-            richTextStringBuilder.append(currentNodeType.literal)
+            text
           }
+          richTextStringBuilder.append(sanitizedText)
 
           null
         }

--- a/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
+++ b/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
@@ -139,7 +139,12 @@ private fun computeRichTextString(astNode: AstNode, renderer: MediaRenderer): Ri
         }
         is AstStrongEmphasis -> richTextStringBuilder.pushFormat(RichTextString.Format.Bold)
         is AstText -> {
-          richTextStringBuilder.append(currentNodeType.literal)
+          if (currentNode.links.parent?.type is AstLink) {
+            richTextStringBuilder.append(stripHashAndAt(currentNodeType.literal))
+          } else {
+            richTextStringBuilder.append(currentNodeType.literal)
+          }
+
           null
         }
         is AstLinkReferenceDefinition -> richTextStringBuilder.pushFormat(
@@ -176,6 +181,8 @@ private fun computeRichTextString(astNode: AstNode, renderer: MediaRenderer): Ri
 
   return richTextStringBuilder.toRichTextString()
 }
+
+private fun stripHashAndAt(input: String): String = input.filterNot { it == '#' || it == '@' }
 
 private data class AstNodeTraversalEntry(
   val astNode: AstNode,

--- a/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
+++ b/richtext-markdown/src/commonMain/kotlin/com/halilibo/richtext/markdown/MarkdownRichText.kt
@@ -141,7 +141,7 @@ private fun computeRichTextString(astNode: AstNode, renderer: MediaRenderer): Ri
         is AstText -> {
           val text = currentNodeType.literal
           val sanitizedText = if (renderer.shouldSanitizeUriLabel() && currentNode.links.parent?.type is AstLink) {
-            stripHashAndAt(text)
+            renderer.sanitizeUriLabel(text)
           } else {
             text
           }
@@ -183,8 +183,6 @@ private fun computeRichTextString(astNode: AstNode, renderer: MediaRenderer): Ri
 
   return richTextStringBuilder.toRichTextString()
 }
-
-private fun stripHashAndAt(input: String): String = input.filterNot { it == '#' || it == '@' }
 
 private data class AstNodeTraversalEntry(
   val astNode: AstNode,

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/MediaRenderer.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/MediaRenderer.kt
@@ -12,4 +12,5 @@ public interface MediaRenderer {
   public fun renderHashtag(tag: String, richTextStringBuilder: RichTextString.Builder)
   public fun renderLinkPreview(title: String?, uri: String, richTextStringBuilder: RichTextString.Builder)
   public fun shouldRenderLinkPreview(title: String?, uri: String): Boolean
+  public fun shouldSanitizeUriLabel(): Boolean
 }

--- a/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/MediaRenderer.kt
+++ b/richtext-ui/src/commonMain/kotlin/com/halilibo/richtext/ui/MediaRenderer.kt
@@ -13,4 +13,5 @@ public interface MediaRenderer {
   public fun renderLinkPreview(title: String?, uri: String, richTextStringBuilder: RichTextString.Builder)
   public fun shouldRenderLinkPreview(title: String?, uri: String): Boolean
   public fun shouldSanitizeUriLabel(): Boolean
+  public fun sanitizeUriLabel(label: String): String
 }


### PR DESCRIPTION
Configurable sanitation of the link label. The renderer provides the method on how to sanitise the link label.

Performance:
For every text node there is an if-test whether to sanitise and whether the parent is a link. Only then will sanitise be called.

Ideally I would only test link nodes but I couldn't find a code path that would change the text just for link nodes.